### PR TITLE
add support for opening relative URLs from popups, fixes #73

### DIFF
--- a/packages/electron-chrome-extensions/src/browser/api/tabs.ts
+++ b/packages/electron-chrome-extensions/src/browser/api/tabs.ts
@@ -143,6 +143,9 @@ export class TabsAPI {
   }
 
   private async create(event: ExtensionEvent, details: chrome.tabs.CreateProperties = {}) {
+    // make URL absolute
+    details.url = new URL(details.url, event.sender.getURL()).href;
+    
     const tab = await this.ctx.store.createTab(details)
     const tabDetails = this.getTabDetails(tab)
     if (details.active) {


### PR DESCRIPTION
Not sure if you're interested in this fix, but it solves https://github.com/samuelmaddock/electron-browser-shell/issues/73